### PR TITLE
画像保存、ファイル取込時整形処理追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# ビルド出力
+bin/
+obj/
+
+# ユーザーごとの設定
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# VS コード生成ファイル
+.vs/
+Generated_Code/
+
+# パッケージ管理
+packages/
+
+# 一時ファイル
+*.log
+*.tmp
+*.bak
+*.cache
+
+# ロックファイル
+project.lock.json
+project.fragment.lock.json
+
+# その他
+*.pdb
+*.exe
+*.dll
+*.db
+*.zip
+
+# OSごとの不要ファイル
+.DS_Store
+Thumbs.db
+desktop.ini

--- a/WordCloudMindMapApp/MainWindow.xaml
+++ b/WordCloudMindMapApp/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="WordCloudMindMapApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Word Cloud Viewer" Height="600" Width="900">
+        Title="Word Cloud Viewer" Height="600" Width="1043">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -20,6 +20,9 @@
             Click="GenerateWordCloud_Click"/>
             <Button Content="ファイル読み込み" Width="120" Height="30" Margin="10,0,0,0"
             Click="LoadFile_Click"/>
+            <Button Content="画像保存" Width="100" Height="30" Margin="10,0,0,0"
+            Click="SaveImage_Click"/>
+
         </StackPanel>
 
         <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1">

--- a/WordCloudMindMapApp/MainWindow.xaml.cs
+++ b/WordCloudMindMapApp/MainWindow.xaml.cs
@@ -32,6 +32,22 @@ namespace WordCloudMindMapApp
                 try
                 {
                     var content = File.ReadAllText(openFileDialog.FileName, Encoding.UTF8);
+                    if (string.IsNullOrWhiteSpace(content))
+                    {
+                        MessageBox.Show("ファイルが空です。");
+                        return;
+                    }
+                    if(content.Contains(" "))
+                    {
+                        content = content.Replace(" ", "");
+                    }else if (content.Contains("\n"))
+                    {
+                        content = content.Replace("\n", "");
+                    }
+                    else if (content.Contains("\r"))
+                    {
+                        content = content.Replace("\r", "");
+                    }
                     InputTextBox.Text = content;
                 }
                 catch (Exception ex)
@@ -140,5 +156,38 @@ namespace WordCloudMindMapApp
             bitmapImage.EndInit();
             return bitmapImage;
         }
+
+        private void SaveImage_Click(object sender, RoutedEventArgs e)
+        {
+            var bitmapSource = WordCloudImage.Source as BitmapSource;
+            if (bitmapSource == null)
+            {
+                MessageBox.Show("保存する画像がありません。");
+                return;
+            }
+
+            var saveFileDialog = new Microsoft.Win32.SaveFileDialog
+            {
+                Filter = "PNG画像 (*.png)|*.png",
+                FileName = "wordcloud.png"
+            };
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                try
+                {
+                    using var fileStream = new FileStream(saveFileDialog.FileName, FileMode.Create);
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+                    encoder.Save(fileStream);
+                    MessageBox.Show("画像を保存しました。");
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show("画像保存エラー: " + ex.Message);
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
#変更内容

- 画像保存 ボタンを追加し、表示中のワードクラウドを PNG 形式で保存できるようにしました。
- 外部ファイル読み込み時に、レイアウト崩れを防ぐための整形処理を追加しました。
- .gitignore に bin/ や obj/ など不要なファイル群を追加

---
#動作確認

- 入力テキストからワードクラウドが正常に生成されることを確認
- 保存した PNG 画像が正しく表示されることを確認
- ファイル読み込み時の表示レイアウトが崩れないことを確認

![image](https://github.com/user-attachments/assets/c8c2e192-b369-4f24-85e3-bf5bd3e2b00d)
